### PR TITLE
로그인 및 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	//JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/com/sparta/task/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/sparta/task/config/PasswordEncoderConfig.java
@@ -1,0 +1,16 @@
+package com.sparta.task.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+
+}

--- a/src/main/java/com/sparta/task/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/task/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.sparta.task.config;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,6 +33,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()  // 인증 없이 접근할 수 있는 경로
             .requestMatchers(HttpMethod.GET, "/api/auth/**").permitAll()  // 인증 없이 접근할 수 있는 경로
+            .requestMatchers("/h2-console/**").permitAll()
             .anyRequest().authenticated()
         )
         .build();

--- a/src/main/java/com/sparta/task/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/task/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.sparta.task.config;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+    return http
+        .csrf(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(STATELESS))
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()  // 인증 없이 접근할 수 있는 경로
+            .requestMatchers(HttpMethod.GET, "/api/auth/**").permitAll()  // 인증 없이 접근할 수 있는 경로
+            .anyRequest().authenticated()
+        )
+        .build();
+  }
+
+}

--- a/src/main/java/com/sparta/task/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/task/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.sparta.task.config;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
+import com.sparta.task.filter.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,12 +13,15 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
+
+  private final JwtFilter jwtFilter;
 
 
   @Bean
@@ -36,6 +40,7 @@ public class SecurityConfig {
             .requestMatchers("/h2-console/**").permitAll()
             .anyRequest().authenticated()
         )
+        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }
 

--- a/src/main/java/com/sparta/task/controller/AuthController.java
+++ b/src/main/java/com/sparta/task/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.sparta.task.controller;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.sparta.task.service.AuthService;
+import com.sparta.task.service.dto.SignInRequest;
+import com.sparta.task.service.dto.SignUpRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("/sign-up")
+  public ResponseEntity<Long> signUp(@RequestBody SignUpRequest signUpRequest) {
+    return ResponseEntity.ok(authService.signUp(signUpRequest));
+  }
+
+  @PostMapping("/sign-in")
+  public ResponseEntity<String> signIn(
+      @RequestBody SignInRequest signInRequest,
+      HttpServletResponse response
+  ) {
+    response.setHeader(AUTHORIZATION, authService.signIn(signInRequest));
+    return ResponseEntity.ok(authService.signIn(signInRequest));
+  }
+}

--- a/src/main/java/com/sparta/task/controller/AuthController.java
+++ b/src/main/java/com/sparta/task/controller/AuthController.java
@@ -4,9 +4,12 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.sparta.task.service.AuthService;
 import com.sparta.task.service.dto.SignInRequest;
+import com.sparta.task.service.dto.SignInResponse;
 import com.sparta.task.service.dto.SignUpRequest;
+import com.sparta.task.service.dto.SignUpResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,16 +24,17 @@ public class AuthController {
   private final AuthService authService;
 
   @PostMapping("/sign-up")
-  public ResponseEntity<Long> signUp(@RequestBody SignUpRequest signUpRequest) {
-    return ResponseEntity.ok(authService.signUp(signUpRequest));
+  public ResponseEntity<SignUpResponse> signUp(@RequestBody SignUpRequest signUpRequest) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(authService.signUp(signUpRequest));
   }
 
   @PostMapping("/sign-in")
-  public ResponseEntity<String> signIn(
+  public ResponseEntity<SignInResponse> signIn(
       @RequestBody SignInRequest signInRequest,
       HttpServletResponse response
   ) {
-    response.setHeader(AUTHORIZATION, authService.signIn(signInRequest));
-    return ResponseEntity.ok(authService.signIn(signInRequest));
+    SignInResponse tokenResponse = authService.signIn(signInRequest);
+    response.setHeader(AUTHORIZATION, tokenResponse.getToken());
+    return ResponseEntity.ok().body(tokenResponse);
   }
 }

--- a/src/main/java/com/sparta/task/controller/TestController.java
+++ b/src/main/java/com/sparta/task/controller/TestController.java
@@ -1,0 +1,17 @@
+package com.sparta.task.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TestController {
+
+  @GetMapping("/test")
+  public ResponseEntity<String> test() {
+    return ResponseEntity.ok().body("테스트 성공");
+  }
+
+}

--- a/src/main/java/com/sparta/task/docs/auth-api.http
+++ b/src/main/java/com/sparta/task/docs/auth-api.http
@@ -4,7 +4,8 @@ Content-Type: application/json
 
 {
   "username": "user",
-  "password": "password"
+  "password": "password",
+  "nickname": "아린"
 }
 
 ### 일반 사용자 로그인 API

--- a/src/main/java/com/sparta/task/docs/auth-api.http
+++ b/src/main/java/com/sparta/task/docs/auth-api.http
@@ -1,0 +1,20 @@
+### 일반 사용자 회원 가입 API
+POST http://localhost:8080/api/auth/sign-up
+Content-Type: application/json
+
+{
+  "username": "user",
+  "password": "password"
+}
+
+### 일반 사용자 로그인 API
+POST http://localhost:8080/api/auth/sign-in
+Content-Type: application/json
+
+{
+  "username": "user",
+  "password": "password"
+}
+> {%
+  client.global.set("token", response.headers.valueOf("Authorization"))
+%}

--- a/src/main/java/com/sparta/task/docs/auth-api.http
+++ b/src/main/java/com/sparta/task/docs/auth-api.http
@@ -19,3 +19,8 @@ Content-Type: application/json
 > {%
   client.global.set("token", response.headers.valueOf("Authorization"))
 %}
+
+### 테스트
+GET http://localhost:8080/api/test
+Content-Type: application/json
+Authorization: {{token}}

--- a/src/main/java/com/sparta/task/domain/RefreshToken.java
+++ b/src/main/java/com/sparta/task/domain/RefreshToken.java
@@ -1,0 +1,54 @@
+package com.sparta.task.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Date;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+  private static final long REFRESH_TOKEN_TIME = 24 * 60 * 60 * 1000L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @Column(nullable = false)
+  private Long userId;
+  @Column(nullable = false)
+  private String refreshToken;
+  @Column(nullable = false)
+  private Date expiration;
+
+  private RefreshToken(Long userId, String refreshToken, Date expiration) {
+    this.userId = userId;
+    this.refreshToken = refreshToken;
+    this.expiration = expiration;
+  }
+
+  public static RefreshToken createRefreshToken(Long userId) {
+    Date issuedDate = new Date();
+    Date expirationDate = new Date(issuedDate.getTime() + REFRESH_TOKEN_TIME);
+
+    SecureRandom secureRandom = new SecureRandom();
+    byte[] randomBytes = new byte[24];
+    secureRandom.nextBytes(randomBytes);
+    String refreshToken = Base64.getEncoder().encodeToString(randomBytes);
+
+    return new RefreshToken(userId, refreshToken, expirationDate);
+  }
+
+  public void updateExpiration() {
+    this.expiration = new Date(System.currentTimeMillis() + REFRESH_TOKEN_TIME);
+  }
+
+}

--- a/src/main/java/com/sparta/task/domain/User.java
+++ b/src/main/java/com/sparta/task/domain/User.java
@@ -1,0 +1,42 @@
+package com.sparta.task.domain;
+
+import com.sparta.task.domain.vo.Role;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "P_USER")
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @Column(nullable = false)
+  private String username;
+  @Column(nullable = false)
+  private String password;
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private Role role = Role.ROLE_USER;
+
+  private User(String username, String password) {
+    this.username = username;
+    this.password = password;
+  }
+
+  public static User of(String username, String encodedPassword) {
+    return new User(username, encodedPassword);
+  }
+
+}

--- a/src/main/java/com/sparta/task/domain/User.java
+++ b/src/main/java/com/sparta/task/domain/User.java
@@ -22,21 +22,24 @@ public class User {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  @Column(nullable = false)
+  @Column(nullable = false, unique = true)
   private String username;
   @Column(nullable = false)
   private String password;
+  @Column(nullable = false, unique = true)
+  private String nickname;
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private Role role = Role.ROLE_USER;
 
-  private User(String username, String password) {
+  private User(String username, String password, String nickname) {
     this.username = username;
     this.password = password;
+    this.nickname = nickname;
   }
 
-  public static User of(String username, String encodedPassword) {
-    return new User(username, encodedPassword);
+  public static User of(String username, String encodedPassword, String nickname) {
+    return new User(username, encodedPassword, nickname);
   }
 
 }

--- a/src/main/java/com/sparta/task/domain/UserPrincipal.java
+++ b/src/main/java/com/sparta/task/domain/UserPrincipal.java
@@ -1,0 +1,13 @@
+package com.sparta.task.domain;
+
+public record UserPrincipal(
+    Long id,
+    String username,
+    String role
+) {
+
+  public static UserPrincipal of(Long id, String username, String role) {
+    return new UserPrincipal(id, username, role);
+  }
+
+}

--- a/src/main/java/com/sparta/task/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sparta/task/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.task.domain.repository;
+
+import com.sparta.task.domain.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+  Optional<RefreshToken> findByUserId(Long userId);
+
+}

--- a/src/main/java/com/sparta/task/domain/repository/UserRepository.java
+++ b/src/main/java/com/sparta/task/domain/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.task.domain.repository;
+
+import com.sparta.task.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByUsername(String username);
+
+  boolean existsByUsername(String username);
+
+}

--- a/src/main/java/com/sparta/task/domain/vo/Role.java
+++ b/src/main/java/com/sparta/task/domain/vo/Role.java
@@ -1,0 +1,16 @@
+package com.sparta.task.domain.vo;
+
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+  ROLE_USER("일반 사용자"),
+  ROLE_MASTER("관리자");
+
+  private final String description;
+
+  Role(String description) {
+    this.description = description;
+  }
+}

--- a/src/main/java/com/sparta/task/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sparta/task/filter/AuthenticationFilter.java
@@ -1,0 +1,104 @@
+package com.sparta.task.filter;
+
+import static com.sparta.task.util.JwtUtil.BEARER_PREFIX;
+
+import com.sparta.task.domain.UserPrincipal;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+  @Value("${jwt.secret-key}")
+  private String secretKey;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+    if (StringUtils.hasText(authorizationHeader)) {
+      try {
+        String token = extractToken(authorizationHeader);
+        Claims claims = validateToken(token);
+
+        String id = (String) claims.get("id");
+        String username = (String) claims.get("username");
+        String role = (String) claims.get("role");
+
+        UserPrincipal userPrincipal =
+            UserPrincipal.of(
+                Long.valueOf(id),
+                username,
+                role
+            );
+
+        GrantedAuthority authority = new SimpleGrantedAuthority(role);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+            userPrincipal, null, List.of(authority)
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      } catch (Exception e) {
+        log.error("Authentication 실패: {}", e.getMessage());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
+      }
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  // JWT 토큰 추출
+  private String extractToken(String authorizationHeader) {
+    if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
+      throw new IllegalArgumentException("올바르지 않은 토큰 값입니다.");
+    }
+    return authorizationHeader.substring(BEARER_PREFIX.length());
+  }
+
+  // 토큰 유효성 검사
+  private Claims validateToken(String token) {
+    SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    try {
+      return Jwts.parser()
+          .verifyWith(key)
+          .build()
+          .parseSignedClaims(token)
+          .getPayload();
+    } catch (Exception unexpectedException) {
+      throw new RuntimeException(unexpectedException);
+    }
+  }
+
+  private static final List<String> EXCLUDE_URLS = List.of(
+      "/api/auth/sign-in",
+      "/api/auth/sign-up",
+      "/api/auth/v3/api-docs"
+  );
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return EXCLUDE_URLS.stream().anyMatch(url -> request.getRequestURI().startsWith(url));
+  }
+}

--- a/src/main/java/com/sparta/task/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sparta/task/filter/AuthenticationFilter.java
@@ -4,6 +4,7 @@ import static com.sparta.task.util.JwtUtil.BEARER_PREFIX;
 
 import com.sparta.task.domain.UserPrincipal;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.FilterChain;
@@ -86,6 +87,8 @@ public class AuthenticationFilter extends OncePerRequestFilter {
           .build()
           .parseSignedClaims(token)
           .getPayload();
+    } catch (ExpiredJwtException e) {
+      throw new RuntimeException("Expired token: " + e.getMessage());
     } catch (Exception unexpectedException) {
       throw new RuntimeException(unexpectedException);
     }
@@ -94,7 +97,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
   private static final List<String> EXCLUDE_URLS = List.of(
       "/api/auth/sign-in",
       "/api/auth/sign-up",
-      "/api/auth/v3/api-docs"
+      "/h2-console"
   );
 
   @Override

--- a/src/main/java/com/sparta/task/filter/JwtFilter.java
+++ b/src/main/java/com/sparta/task/filter/JwtFilter.java
@@ -29,7 +29,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
 @Component
-public class AuthenticationFilter extends OncePerRequestFilter {
+public class JwtFilter extends OncePerRequestFilter {
 
   @Value("${jwt.secret-key}")
   private String secretKey;

--- a/src/main/java/com/sparta/task/service/AuthService.java
+++ b/src/main/java/com/sparta/task/service/AuthService.java
@@ -1,0 +1,62 @@
+package com.sparta.task.service;
+
+import com.sparta.task.domain.User;
+import com.sparta.task.domain.repository.UserRepository;
+import com.sparta.task.service.dto.SignInRequest;
+import com.sparta.task.service.dto.SignUpRequest;
+import com.sparta.task.util.JwtUtil;
+import jdk.jshell.spi.ExecutionControl.UserException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
+  private final String MASTER_TOKEN = "MASTER_TOKEN";
+
+  @Transactional
+  public Long signUp(SignUpRequest signUpRequest) {
+    validateDuplicateUsername(signUpRequest.getUsername());
+    String encodedPassword = passwordEncoder.encode(signUpRequest.getPassword());
+    User user = signUpRequest.toEntity(encodedPassword);
+    return userRepository.save(user).getId();
+  }
+
+
+  public String signIn(SignInRequest signInRequest) {
+    User verifiedUser = verifyUser(signInRequest);
+    return jwtUtil.createToken(
+        verifiedUser.getId(),
+        verifiedUser.getUsername(),
+        verifiedUser.getRole().toString()
+    );
+  }
+
+  private User verifyUser(SignInRequest signInRequest) {
+    User user = userRepository.findByUsername(signInRequest.getUsername()).orElseThrow(
+        () -> new IllegalArgumentException("사용자를 찾을 수 없습니다.")
+    );
+    checkPassword(user, signInRequest.getPassword());
+    return user;
+
+  }
+
+  private void checkPassword(User user, String password) {
+    if (!passwordEncoder.matches(password, user.getPassword())) {
+      throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
+    }
+  }
+  private void validateDuplicateUsername(String username) {
+    if (userRepository.existsByUsername(username)) {
+      throw new IllegalArgumentException("중복된 사용자 이름입니다.");
+    }
+  }
+
+}

--- a/src/main/java/com/sparta/task/service/AuthService.java
+++ b/src/main/java/com/sparta/task/service/AuthService.java
@@ -35,7 +35,6 @@ public class AuthService {
     return SignUpResponse.fromEntity(userRepository.save(user));
   }
 
-
   public SignInResponse signIn(SignInRequest signInRequest) {
     User verifiedUser = verifyUser(signInRequest);
 

--- a/src/main/java/com/sparta/task/service/AuthService.java
+++ b/src/main/java/com/sparta/task/service/AuthService.java
@@ -1,11 +1,16 @@
 package com.sparta.task.service;
 
+import com.sparta.task.domain.RefreshToken;
 import com.sparta.task.domain.User;
+import com.sparta.task.domain.repository.RefreshTokenRepository;
 import com.sparta.task.domain.repository.UserRepository;
 import com.sparta.task.service.dto.SignInRequest;
+import com.sparta.task.service.dto.SignInResponse;
 import com.sparta.task.service.dto.SignUpRequest;
+import com.sparta.task.service.dto.SignUpResponse;
 import com.sparta.task.util.JwtUtil;
-import jdk.jshell.spi.ExecutionControl.UserException;
+import java.util.Date;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,26 +22,40 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
   private final UserRepository userRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtUtil jwtUtil;
   private final String MASTER_TOKEN = "MASTER_TOKEN";
 
   @Transactional
-  public Long signUp(SignUpRequest signUpRequest) {
+  public SignUpResponse signUp(SignUpRequest signUpRequest) {
     validateDuplicateUsername(signUpRequest.getUsername());
     String encodedPassword = passwordEncoder.encode(signUpRequest.getPassword());
     User user = signUpRequest.toEntity(encodedPassword);
-    return userRepository.save(user).getId();
+    return SignUpResponse.fromEntity(userRepository.save(user));
   }
 
 
-  public String signIn(SignInRequest signInRequest) {
+  public SignInResponse signIn(SignInRequest signInRequest) {
     User verifiedUser = verifyUser(signInRequest);
-    return jwtUtil.createToken(
+
+    Optional<RefreshToken> existingRefreshToken = refreshTokenRepository.findByUserId(verifiedUser.getId());
+
+    RefreshToken refreshToken;
+    if (existingRefreshToken.isPresent()) {
+      refreshToken = existingRefreshToken.get();
+      refreshToken.updateExpiration();
+      refreshTokenRepository.save(refreshToken);
+    } else {
+      refreshToken = RefreshToken.createRefreshToken(verifiedUser.getId());
+      refreshTokenRepository.save(refreshToken);
+    }
+
+    return new SignInResponse(jwtUtil.createAccessToken(
         verifiedUser.getId(),
         verifiedUser.getUsername(),
         verifiedUser.getRole().toString()
-    );
+    ));
   }
 
   private User verifyUser(SignInRequest signInRequest) {
@@ -59,4 +78,21 @@ public class AuthService {
     }
   }
 
+  public String refreshAccessToken(Long userId) {
+    RefreshToken existingRefreshToken = refreshTokenRepository.findByUserId(userId)
+        .orElseThrow(() -> new RuntimeException("refresh token 이 존재하지 않습니다."));
+
+    if (existingRefreshToken.getExpiration().before(new Date())) {
+      throw new RuntimeException("refresh token 이 만료되었습니다.");
+    }
+
+    User user = userRepository.findById(existingRefreshToken.getUserId())
+        .orElseThrow(() -> new RuntimeException("사용자가 존재하지 않습니다."));
+
+    return jwtUtil.createAccessToken(
+        user.getId(),
+        user.getUsername(),
+        user.getRole().toString()
+    );
+  }
 }

--- a/src/main/java/com/sparta/task/service/dto/SignInRequest.java
+++ b/src/main/java/com/sparta/task/service/dto/SignInRequest.java
@@ -1,5 +1,6 @@
 package com.sparta.task.service.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SignInRequest {
 
+  @NotBlank(message = "사용자명은 필수값입니다.")
   private String username;
+  @NotBlank(message = "비밀번호는 필수값입니다.")
   private String password;
 
 }

--- a/src/main/java/com/sparta/task/service/dto/SignInRequest.java
+++ b/src/main/java/com/sparta/task/service/dto/SignInRequest.java
@@ -1,0 +1,14 @@
+package com.sparta.task.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignInRequest {
+
+  private String username;
+  private String password;
+}

--- a/src/main/java/com/sparta/task/service/dto/SignInResponse.java
+++ b/src/main/java/com/sparta/task/service/dto/SignInResponse.java
@@ -7,9 +7,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class SignInRequest {
-
-  private String username;
-  private String password;
-
+public class SignInResponse {
+  private String token;
 }

--- a/src/main/java/com/sparta/task/service/dto/SignUpRequest.java
+++ b/src/main/java/com/sparta/task/service/dto/SignUpRequest.java
@@ -1,0 +1,20 @@
+package com.sparta.task.service.dto;
+
+import com.sparta.task.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignUpRequest {
+
+  private String username;
+  private String password;
+
+  public User toEntity(String encodedPassword) {
+    return User.of(username, encodedPassword);
+  }
+
+}

--- a/src/main/java/com/sparta/task/service/dto/SignUpRequest.java
+++ b/src/main/java/com/sparta/task/service/dto/SignUpRequest.java
@@ -1,6 +1,7 @@
 package com.sparta.task.service.dto;
 
 import com.sparta.task.domain.User;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,8 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SignUpRequest {
 
+  @NotBlank(message = "사용자명은 필수값입니다.")
   private String username;
+  @NotBlank(message = "비밀번호는 필수값입니다.")
   private String password;
+  @NotBlank(message = "닉네임은 필수값입니다.")
   private String nickname;
 
   public User toEntity(String encodedPassword) {

--- a/src/main/java/com/sparta/task/service/dto/SignUpRequest.java
+++ b/src/main/java/com/sparta/task/service/dto/SignUpRequest.java
@@ -12,9 +12,10 @@ public class SignUpRequest {
 
   private String username;
   private String password;
+  private String nickname;
 
   public User toEntity(String encodedPassword) {
-    return User.of(username, encodedPassword);
+    return User.of(username, encodedPassword, nickname);
   }
 
 }

--- a/src/main/java/com/sparta/task/service/dto/SignUpResponse.java
+++ b/src/main/java/com/sparta/task/service/dto/SignUpResponse.java
@@ -1,0 +1,24 @@
+package com.sparta.task.service.dto;
+
+import com.sparta.task.domain.User;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpResponse {
+
+  private String username;
+  private String nickname;
+  private Map<String, String> authorities = new HashMap<>();
+
+  public static SignUpResponse fromEntity(User user) {
+    Map<String, String> authorities = new HashMap<>();
+    authorities.put("authorityName", user.getRole().toString());
+    return new SignUpResponse(user.getUsername(), user.getNickname(), authorities);
+  }
+}

--- a/src/main/java/com/sparta/task/service/dto/SignUpResponse.java
+++ b/src/main/java/com/sparta/task/service/dto/SignUpResponse.java
@@ -17,6 +17,11 @@ public class SignUpResponse {
   private Map<String, String> authorities = new HashMap<>();
 
   public static SignUpResponse fromEntity(User user) {
+
+    if (user == null) {
+      throw new IllegalArgumentException("User must not be null");
+    }
+
     Map<String, String> authorities = new HashMap<>();
     authorities.put("authorityName", user.getRole().toString());
     return new SignUpResponse(user.getUsername(), user.getNickname(), authorities);

--- a/src/main/java/com/sparta/task/util/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/task/util/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.sparta.task.util;
+
+import com.sparta.task.service.AuthService;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Slf4j
+@ControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+  private final AuthService authService;
+  private final JwtUtil jwtUtil;
+
+  @ExceptionHandler(ExpiredJwtException.class)
+  public ResponseEntity<String> handleExpiredToken(ExpiredJwtException ex,
+      @RequestHeader("Authorization") String accessToken) {
+    try {
+      Long userId = Long.valueOf((String) jwtUtil.extractClaims(accessToken).get("Id"));
+      String newAccessToken = authService.refreshAccessToken(userId);
+      return ResponseEntity.ok()
+          .header(HttpHeaders.AUTHORIZATION, newAccessToken)
+          .body("access token 이 갱신되었습니다.");
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+          .body("refresh token 이 유효하지 않습니다.");
+    }
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<String> handleException(Exception ex) {
+    log.error(ex.getMessage(), ex);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body("내부 서버 오류가 발생했습니다.");
+  }
+}

--- a/src/main/java/com/sparta/task/util/JwtUtil.java
+++ b/src/main/java/com/sparta/task/util/JwtUtil.java
@@ -1,0 +1,50 @@
+package com.sparta.task.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+  public static final String BEARER_PREFIX = "Bearer ";
+  public static final String ID = "id";
+  public static final String USERNAME = "username";
+  public static final String ROLE = "role";
+  private final long TOKEN_TIME = 60 * 30 * 1000L;
+
+  @Value("${jwt.secret-key}")
+  private String secretKey;
+  @Value("${spring.application.name}")
+  private String issuer;
+  private Key key;
+  private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+  // 바이트 배열로 변환 후 JWT 서명에 사용할 HMAC SHA 알고리즘용 키 초기화
+  @PostConstruct
+  public void init() {
+    key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+  }
+
+  // 토큰 생성
+  public String createToken(Long userId, String username, String roleDetails) {
+    Date issuedDate = new Date();
+
+    return BEARER_PREFIX +
+        Jwts.builder()
+            .issuer(issuer)
+            .issuedAt(issuedDate)
+            .claim(ID, userId.toString())
+            .claim(USERNAME, username)
+            .claim(ROLE, roleDetails)
+            .expiration(new Date(issuedDate.getTime() + TOKEN_TIME))
+            .signWith(key)  // HMAC-SHA256 알고리즘을 명시적으로 지정하지 않아도 됨
+            .compact();
+  }
+}

--- a/src/main/java/com/sparta/task/util/JwtUtil.java
+++ b/src/main/java/com/sparta/task/util/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.sparta.task.util;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -7,6 +8,7 @@ import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +19,8 @@ public class JwtUtil {
   public static final String ID = "id";
   public static final String USERNAME = "username";
   public static final String ROLE = "role";
-  private final long TOKEN_TIME = 60 * 30 * 1000L;
+  private final long ACCESS_TOKEN_TIME = 60 * 30 * 1000L;
+
 
   @Value("${jwt.secret-key}")
   private String secretKey;
@@ -33,7 +36,7 @@ public class JwtUtil {
   }
 
   // 토큰 생성
-  public String createToken(Long userId, String username, String roleDetails) {
+  public String createAccessToken(Long userId, String username, String roleDetails) {
     Date issuedDate = new Date();
 
     return BEARER_PREFIX +
@@ -43,8 +46,16 @@ public class JwtUtil {
             .claim(ID, userId.toString())
             .claim(USERNAME, username)
             .claim(ROLE, roleDetails)
-            .expiration(new Date(issuedDate.getTime() + TOKEN_TIME))
-            .signWith(key)  // HMAC-SHA256 알고리즘을 명시적으로 지정하지 않아도 됨
+            .expiration(new Date(issuedDate.getTime() + ACCESS_TOKEN_TIME))
+            .signWith(key)
             .compact();
+  }
+
+  public Claims extractClaims(String token) {
+      return Jwts.parser()
+          .verifyWith((SecretKey) key)
+          .build()
+          .parseSignedClaims(token)
+          .getPayload();
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  application:
+    name: java-service
+  # H2 Database 설정
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: 'jdbc:h2:mem:test'
+    username: username
+    password: password
+
+  # H2 Console 설정
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+jwt:
+  expiration-minutes: 30
+  secret-key: sparta-local-authenticate-secret-key

--- a/src/test/java/com/sparta/task/AuthControllerTest.java
+++ b/src/test/java/com/sparta/task/AuthControllerTest.java
@@ -1,0 +1,60 @@
+package com.sparta.task;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sparta.task.domain.User;
+import com.sparta.task.domain.repository.UserRepository;
+import com.sparta.task.mock.WithCustomMockUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private PasswordEncoder passwordEncoder;
+
+  @BeforeEach
+  void setUp() {
+    String encodedPassword = passwordEncoder.encode("비밀번호");
+    User user = User.of("username", encodedPassword, "아린");
+    userRepository.save(user);
+  }
+
+  @Test
+  public void testLoginSuccess() throws Exception {
+    mockMvc.perform(post("/api/auth/sign-in")
+            .contentType("application/json")
+            .content("{ \"username\": \"username\", \"password\": \"비밀번호\" }"))
+        .andExpect(status().isOk())
+        .andExpect(header().exists("Authorization"))
+        .andExpect(jsonPath("$.token").exists());
+  }
+
+  // JUnit 테스트 작성
+  @Test
+  @WithCustomMockUser
+  public void testAuthentication() throws Exception {
+    mockMvc.perform(get("/api/test")
+            .header("X-AUTH-TOKEN", "aaaaaaa"))
+        .andExpect(MockMvcResultMatchers.status().isOk());
+  }
+
+}

--- a/src/test/java/com/sparta/task/AuthControllerTest.java
+++ b/src/test/java/com/sparta/task/AuthControllerTest.java
@@ -57,4 +57,6 @@ public class AuthControllerTest {
         .andExpect(MockMvcResultMatchers.status().isOk());
   }
 
+
+
 }

--- a/src/test/java/com/sparta/task/mock/WithCustomMockUser.java
+++ b/src/test/java/com/sparta/task/mock/WithCustomMockUser.java
@@ -1,0 +1,13 @@
+package com.sparta.task.mock;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+
+  String username() default "username";
+  long id() default 1L;
+}

--- a/src/test/java/com/sparta/task/mock/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/com/sparta/task/mock/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,37 @@
+package com.sparta.task.mock;
+
+import com.sparta.task.domain.UserPrincipal;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements
+    WithSecurityContextFactory<WithCustomMockUser> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+    UserPrincipal userPrincipal = UserPrincipal.of(
+        annotation.id(),
+        annotation.username(),
+        "ROLE_USER"
+    );
+
+    GrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER");
+
+    Authentication auth = new UsernamePasswordAuthenticationToken(
+        userPrincipal,
+        null,
+        List.of(authority)
+    );
+
+    SecurityContext context = SecurityContextHolder.getContext();
+    context.setAuthentication(auth);
+
+    return context;
+  }
+}

--- a/src/test/java/com/sparta/task/mock/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/com/sparta/task/mock/WithCustomMockUserSecurityContextFactory.java
@@ -29,7 +29,7 @@ public class WithCustomMockUserSecurityContextFactory implements
         List.of(authority)
     );
 
-    SecurityContext context = SecurityContextHolder.getContext();
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
     context.setAuthentication(auth);
 
     return context;


### PR DESCRIPTION
## 개요
로그인 API와 JWT 토큰 필터를 구현합니다.

## 작업 내용
- 로그인 시 토큰을 생성하여 반환
- 로그인 API http 테스트 작성
- JWT 토큰 추출 후 유효성 검증 필터 구현
- User 사용자 인증 필터 구현

## http 테스트 
![image](https://github.com/user-attachments/assets/9523310e-2df4-4c59-8ad3-a8752b9776f1)
![image](https://github.com/user-attachments/assets/b421b32b-8dcc-489e-950c-a3d2bb56c9a9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 인증을 위한 새로운 RESTful 엔드포인트 추가: `/api/auth/sign-up` 및 `/api/auth/sign-in`.
	- JWT 필터를 통한 인증 기능 구현.
	- 사용자 역할을 정의하는 `Role` 열거형 추가.
	- 사용자 세부 정보를 포함하는 `UserPrincipal` 레코드 추가.
	- 비밀번호 인코딩을 위한 설정 클래스 추가.

- **버그 수정**
	- JWT 만료 시 새로운 토큰을 반환하는 예외 처리 메커니즘 추가.

- **문서화**
	- API 엔드포인트에 대한 문서 업데이트.

- **테스트**
	- 인증 기능을 위한 단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->